### PR TITLE
enable utf-8 support

### DIFF
--- a/src/system/apps/seiscomp/py-wrapper
+++ b/src/system/apps/seiscomp/py-wrapper
@@ -51,7 +51,7 @@ export PATH=$SEISCOMP_ROOT/bin:$PATH
 export LD_LIBRARY_PATH=$SEISCOMP_ROOT/lib:$LD_LIBRARY_PATH
 export PYTHONPATH=$SEISCOMP_ROOT/lib/python:$PYTHONPATH
 export MANPATH=$SEISCOMP_ROOT/share/man:$MANPATH
-export LC_ALL=C
+export LC_ALL=en_US.UTF-8
 
 # The path of the Python executable is configured using cmake.
 python_executable="%s"


### PR DESCRIPTION
Fix Python exception when reading utf-8 text:

<pre>
$ seiscomp exec python3
Python 3.6.10 (default, Jan 16 2020, 09:12:04) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> open('test.txt').read()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
</pre>