### PR TITLE
[system] fixed bug in py-wrapper

### DIFF
--- a/src/system/apps/seiscomp/py-wrapper
+++ b/src/system/apps/seiscomp/py-wrapper
@@ -40,8 +40,8 @@ os.chmod("seiscomp-python", permissions)
 
 
 wrapper="""#!/bin/sh
-# Determine the full path of the 'seiscomp' utility.
-SEISCOMP_ROOT=`realpath "$0" | sed 's#/bin/seiscomp$##'`
+# Determine the root directory of the 'seiscomp' utility.
+SEISCOMP_ROOT=`realpath "${0%/bin/seiscomp}"`
 # FIXME:
 # - Any portability issues with 'realpath'?
 # - Is there a more portable alternative?


### PR DESCRIPTION
If `$SEISCOMP_ROOT/bin` is a symbolic link to another SeisComP installation, the previous determination of `$SEISCOMP_ROOT` would fail. This PR fixes that issue.