### PR TITLE
[system] py-wrapper enhancements

### DIFF
--- a/src/system/apps/seiscomp/py-wrapper
+++ b/src/system/apps/seiscomp/py-wrapper
@@ -57,12 +57,12 @@ then
 else
     # $0 is NOT a link
     case "$0" in
+        */*)
         /*)
             d="$0"
             ;;
         *)
-            # determine full path without canonicalizing
-            d="$(which "$0")"
+            d="$(command -v "$0")"
             ;;
     esac
 fi

--- a/src/system/apps/seiscomp/py-wrapper
+++ b/src/system/apps/seiscomp/py-wrapper
@@ -39,18 +39,26 @@ os.chmod("seiscomp-python", permissions)
 
 
 
-wrapper="""#!/bin/sh
+wrapper="""#!/bin/sh -e
+
+normalized_dirname() {
+    # Normalize directory name without following symlinks.
+    # Brute-force but portable.
+    cd "${1%%/*}" && pwd || exit 1
+}
+
 # Determine the root directory of the 'seiscomp' utility.
-SEISCOMP_ROOT=`realpath "${0%%/bin/seiscomp}"`
+d="$(normalized_dirname "$0")"
+SEISCOMP_ROOT="$(realpath "${d%%/bin}")"
 # FIXME:
 # - Any portability issues with 'realpath'?
 # - Is there a more portable alternative?
 
 export SEISCOMP_ROOT
-export PATH=$SEISCOMP_ROOT/bin:$PATH
-export LD_LIBRARY_PATH=$SEISCOMP_ROOT/lib:$LD_LIBRARY_PATH
-export PYTHONPATH=$SEISCOMP_ROOT/lib/python:$PYTHONPATH
-export MANPATH=$SEISCOMP_ROOT/share/man:$MANPATH
+export PATH="$SEISCOMP_ROOT/bin:$PATH"
+export LD_LIBRARY_PATH="$SEISCOMP_ROOT/lib:$LD_LIBRARY_PATH"
+export PYTHONPATH="$SEISCOMP_ROOT/lib/python:$PYTHONPATH"
+export MANPATH="$SEISCOMP_ROOT/share/man:$MANPATH"
 export LC_ALL=C
 
 # The path of the Python executable is configured using cmake.
@@ -62,7 +70,7 @@ case $1 in
         exec "$@"
         ;;
     *)
-        exec $python_executable $SEISCOMP_ROOT/bin/seiscomp-control.py "$@"
+        exec "$python_executable" "$SEISCOMP_ROOT/bin/seiscomp-control.py" "$@"
         ;;
 esac
 """ % (PYTHON_EXECUTABLE,)

--- a/src/system/apps/seiscomp/py-wrapper
+++ b/src/system/apps/seiscomp/py-wrapper
@@ -41,6 +41,32 @@ os.chmod("seiscomp-python", permissions)
 
 wrapper="""#!/bin/sh -e
 
+# Resolve softlink to seiscomp executable first
+if test -L "$0"
+then
+    # $0 is a link
+    target="$(readlink "$0")"
+    case "$target" in
+        /*)
+            d="$target"
+            ;;
+        *)
+            d="$(dirname "$0")/$target"
+            ;;
+    esac
+else
+    # $0 is NOT a link
+    case "$0" in
+        /*)
+            d="$0"
+            ;;
+        *)
+            # determine full path without canonicalizing
+            d="$(which "$0")"
+            ;;
+    esac
+fi
+
 normalized_dirname() {
     # Normalize directory name without following symlinks.
     # Brute-force but portable.
@@ -48,7 +74,7 @@ normalized_dirname() {
 }
 
 # Determine the root directory of the 'seiscomp' utility.
-d="$(normalized_dirname "$0")"
+d="$(normalized_dirname "$d")"
 SEISCOMP_ROOT="$(realpath "${d%%/bin}")"
 # FIXME:
 # - Any portability issues with 'realpath'?
@@ -66,7 +92,7 @@ python_executable="%s"
 
 case $1 in
     exec)
-        shift;
+        shift
         exec "$@"
         ;;
     *)

--- a/src/system/apps/seiscomp/seiscomp-control.py
+++ b/src/system/apps/seiscomp/seiscomp-control.py
@@ -152,15 +152,15 @@ def has_module(name):
 
 
 def dump_paths():
-    print("--------------------")
-    print("SEISCOMP_ROOT=%s" % SEISCOMP_ROOT)
-    print("PATH=%s" % os.environ["PATH"])
-    print("%s=%s" % (SysLibraryPathVar, os.environ[SysLibraryPathVar]))
+    print('--------------------')
+    print('SEISCOMP_ROOT="%s"' % SEISCOMP_ROOT)
+    print('PATH="%s"' % os.environ["PATH"])
+    print('%s="%s"' % (SysLibraryPathVar, os.environ[SysLibraryPathVar]))
     if SysFrameworkPathVar:
-        print("%s=%s" % (SysFrameworkPathVar, os.environ[SysFrameworkPathVar]))
-    print("PYTHONPATH=%s" % sys.path)
-    print("CWD=%s" % os.getcwd())
-    print("--------------------")
+        print('%s="%s"' % (SysFrameworkPathVar, os.environ[SysFrameworkPathVar]))
+    print('PYTHONPATH="%s"' % sys.path)
+    print('CWD="%s"' % os.getcwd())
+    print('--------------------')
 
 
 # Returns whether a module should run or not. It simply returns if its
@@ -565,18 +565,18 @@ def on_print(args, flags):
         for mod in mods:
             mod.printCrontab()
     elif args[0] == "env":
-        print("export SEISCOMP_ROOT=%s" % SEISCOMP_ROOT)
-        print("export PATH=%s:$PATH" % BIN_PATH)
-        print("export %s=%s:$%s" %
+        print('export SEISCOMP_ROOT="%s"' % SEISCOMP_ROOT)
+        print('export PATH="%s:$PATH"' % BIN_PATH)
+        print('export %s="%s:$%s"' %
               (SysLibraryPathVar, get_library_path(), SysLibraryPathVar))
         if sys.platform == "darwin":
-            print("export %s=%s:$%s" % (
+            print('export %s="%s:$%s"' % (
                 SysFrameworkPathVar, get_framework_path(), SysFrameworkPathVar))
 
-        print("export PYTHONPATH=%s:$PYTHONPATH" % PYTHONPATH)
-        print("export MANPATH=%s:$MANPATH" % MANPATH)
-        print("export LC_ALL=C")
-        print("source %s/share/shell-completion/seiscomp.bash" % SEISCOMP_ROOT)
+        print('export PYTHONPATH="%s:$PYTHONPATH"' % PYTHONPATH)
+        print('export MANPATH="%s:$MANPATH"' % MANPATH)
+        print('export LC_ALL=C')
+        print('source "%s/share/shell-completion/seiscomp.bash"' % SEISCOMP_ROOT)
     else:
         error("wrong argument: {crontab|env} expected")
         return 1


### PR DESCRIPTION
The `seiscomp` utility will now work properly in more different scenarios.

Successful test suite:

```
~ % mkdir -p seiscomp-test
~ % cd seiscomp-test
~/seiscomp-test % ln -s ../seiscomp/bin
~/seiscomp-test % ln -s ../seiscomp/lib
~/seiscomp-test % ./bin/seiscomp print env | grep SEISCOMP_ROOT
export SEISCOMP_ROOT="/home/jsaul/seiscomp-test"
~/seiscomp-test % ./bin/./seiscomp print env | grep SEISCOMP_ROOT
export SEISCOMP_ROOT="/home/jsaul/seiscomp-test"
~/seiscomp-test % cd bin
~/seiscomp-test/bin % ./seiscomp print env|grep SEISCOMP_ROOT
export SEISCOMP_ROOT="/home/jsaul/seiscomp-test"
~/seiscomp-test/bin % ././seiscomp print env|grep SEISCOMP_ROOT
export SEISCOMP_ROOT="/home/jsaul/seiscomp-test"
~/seiscomp-test % cd
~ % seiscomp/bin/seiscomp print env | grep SEISCOMP_ROOT
export SEISCOMP_ROOT="/home/jsaul/seiscomp"
~ % seiscomp-test/bin/seiscomp print env | grep SEISCOMP_ROOT
export SEISCOMP_ROOT="/home/jsaul/seiscomp-test"
~ % seiscomp-test/bin/./seiscomp print env | grep SEISCOMP_ROOT
export SEISCOMP_ROOT="/home/jsaul/seiscomp-test"
~ % mkdir -p "seiscomp test"
~ % cd "seiscomp test"
~/seiscomp test % ln -s ../seiscomp/bin
~/seiscomp test % ln -s ../seiscomp/lib
~/seiscomp test % ./bin/seiscomp print env | grep SEISCOMP_ROOT
export SEISCOMP_ROOT="/home/jsaul/seiscomp test"
~/seiscomp test % ./bin/./seiscomp print env | grep SEISCOMP_ROOT
export SEISCOMP_ROOT="/home/jsaul/seiscomp test"
~/seiscomp test % cd bin
~/seiscomp test/bin % ./seiscomp print env|grep SEISCOMP_ROOT
export SEISCOMP_ROOT="/home/jsaul/seiscomp test"
~/seiscomp test/bin % ././seiscomp print env|grep SEISCOMP_ROOT
export SEISCOMP_ROOT="/home/jsaul/seiscomp test"
~ % mkdir /tmp/abc
~ % cd /tmp/abc 
/tmp/abc % ln -s "$HOME/seiscomp test/bin/seiscomp" xyz
/tmp/abc % cd ..                                       
/tmp % abc/xyz print env | grep SEISCOMP_ROOT      
export SEISCOMP_ROOT="/home/jsaul/seiscomp test"
/tmp/abc % export PATH=.:$PATH
/tmp/abc % xyz print env | grep SEISCOMP_ROOT 
export SEISCOMP_ROOT="/home/jsaul/seiscomp test"
