### PR TITLE
[doc] Don't point to SC wiki.

### DIFF
--- a/doc/templates/index.rst
+++ b/doc/templates/index.rst
@@ -4,8 +4,6 @@ Welcome
 
 This is the documentation for the SeisComP version |version| |release|.
 
-For examples and tutorials please check the
-`SeisComP wiki <http://seiscomp.de/>`_.
 Please consider :doc:`contributing</base/contributing-docs>` to this documentation.
 
 .. raw:: html


### PR DESCRIPTION
The wiki won't exist - it's replaced by the forum - and the tutorials are "below" and hardly need mentioning both here and in the table of contents.