### PR TITLE
add missing build dependency libfl-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The following packages should be installed to compile SeisComP:
 - libboost
 - libxml2-dev
 - flex
+- libfl-dev
 - libssl-dev
 - crypto-dev
 - python-dev (optional)


### PR DESCRIPTION
I was prompted by cmake about a missing header file `FlexLexer.h` thats part of `libfl-dev` (on Debian).