### PR TITLE
[doc] fixed some links, added scroll padding to html tag

### DIFF
--- a/doc/base/contributing-docs.rst
+++ b/doc/base/contributing-docs.rst
@@ -70,7 +70,7 @@ Images
 ======
 
 Any images should be placed in a suitable sub-directory of :file:`descriptions/media`.
-Read the :ref:`documentation on image styles <documentation_style_guide>` for more details.
+Read the :ref:`documentation on image styles <documentation_style_guide_images>` for more details.
 The images can then be referred to (in .rst) like::
 
     .. figure::  media/scolv/scolv-overview.png
@@ -572,10 +572,10 @@ References
 .. target-notes::
 
 .. _`SeisComP wiki` : https://www.seiscomp.de/
-.. _`reStructuredText` : https://docutils.sourceforge.net/rst.html
-.. _`Sphinx` : https://sphinx.pocoo.org/index.html
+.. _`reStructuredText` : https://docutils.sourceforge.io/rst.html
+.. _`Sphinx` : https://www.sphinx-doc.org/
 .. _`Python documentation` : https://docs.python.org/
-.. _`introduction to reST` : https://sphinx.pocoo.org/rest.html
-.. _`directives` : https://sphinx.pocoo.org/markup/index.html
+.. _`introduction to reST` : https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
+.. _`directives` : https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html
 .. _`SeisComP on GitHub` : https://github.com/SeisComP
 .. _`discussion forum` : https://forum.seiscomp.de

--- a/doc/base/sass/seiscomp.scss
+++ b/doc/base/sass/seiscomp.scss
@@ -8,6 +8,7 @@
 html {
 	height: 100%;
 	background: $secondaryBackground;
+	scroll-padding-top: 4rem;
 }
 
 body {

--- a/doc/base/style-guide.rst
+++ b/doc/base/style-guide.rst
@@ -319,6 +319,8 @@ avoiding this: "The :program:`scmaster` module has..."
   - STA, LTA, STA/LTA detector
   - TAR file
 
+.. _documentation_style_guide_images:
+
 Adding Images
 =============
 


### PR DESCRIPTION
- The Sphinx / reStructuredText websites have moved - updated the links
- Proper link to the images section in the style-guide
- Added scroll-padding-top to the html tag - when jumping to an anchor, the heading was always hidden behind the header