### PR TITLE
[libmseed] Fix a possible collision of static variables between Python modules

### DIFF
--- a/src/system/libs/3rd-party/libmseed/logging.c
+++ b/src/system/libs/3rd-party/libmseed/logging.c
@@ -23,7 +23,7 @@ void ms_loginit_main (MSLogParam *logp,
 int ms_log_main (MSLogParam *logp, int level, va_list *varlist);
 
 /* Initialize the global logging parameters */
-MSLogParam gMSLogParam = {NULL, NULL, NULL, NULL};
+MSLogParam _gMSLogParam = {NULL, NULL, NULL, NULL};
 
 /***************************************************************************
  * ms_loginit:
@@ -36,7 +36,7 @@ void
 ms_loginit (void (*log_print) (char *), const char *logprefix,
             void (*diag_print) (char *), const char *errprefix)
 {
-  ms_loginit_main (&gMSLogParam, log_print, logprefix, diag_print, errprefix);
+  ms_loginit_main (&_gMSLogParam, log_print, logprefix, diag_print, errprefix);
 } /* End of ms_loginit() */
 
 /***************************************************************************
@@ -161,7 +161,7 @@ ms_log (int level, ...)
 
   va_start (varlist, level);
 
-  retval = ms_log_main (&gMSLogParam, level, &varlist);
+  retval = ms_log_main (&_gMSLogParam, level, &varlist);
 
   va_end (varlist);
 
@@ -185,7 +185,7 @@ ms_log_l (MSLogParam *logp, int level, ...)
   MSLogParam *llog;
 
   if (!logp)
-    llog = &gMSLogParam;
+    llog = &_gMSLogParam;
   else
     llog = logp;
 


### PR DESCRIPTION
This PR fixes a problem that can occur with Python modules using the SeisComP Python API along with 3rd-party Python packages using libmseed. If both SeisComP and the 3rd-party package configure their logging routines using libmseed `ms_loginit()`, one will override the settings of the other, resulting in dangling pointers. As soon as one of the functions pointed to by `log_print`, or `diag_print` is [called](https://github.com/SeisComP/seiscomp/blob/ba124aedd9c0a9ad9708675934891d0bcbb5f0ac/src/system/libs/3rd-party/libmseed/logging.c#L295), a segfault results.

By renaming the static libmseed variable [gMSLogParam](https://github.com/SeisComP/seiscomp/blob/ba124aedd9c0a9ad9708675934891d0bcbb5f0ac/src/system/libs/3rd-party/libmseed/logging.c#L26) in SeisComP, this collision is avoided.