### PR TITLE
Added Cmake minimum version policy to main Makefile, allowing Cmake 4.x to build without errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@ default: all
 
 all:
 	mkdir -p build
-	cd build && ccmake ../ -DCMAKE_INSTALL_PREFIX=${HOME}/seiscomp
+	cd build && ccmake ../ -DCMAKE_INSTALL_PREFIX=${HOME}/seiscomp -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 	echo "*** To build the sources change into the 'build' directory and enter make[ install] ***"
 


### PR DESCRIPTION
Fixes compilation error for Cmake v4.x.
