### PR TITLE
[doc] Fix Mw(Mwp) formula coefficients in glossary

### DIFF
--- a/doc/base/glossary.rst
+++ b/doc/base/glossary.rst
@@ -698,7 +698,7 @@ Scientific and technical terms
       Moment magnitude derived from :term:`Mwp <magnitude, broadband P-wave moment (Mwp)>`
       magnitudes using linear conversion after :cite:t:`whitmore-2002`:
 
-      Mw(Mwp) = 1.31 Mwp - 1.91
+      Mw(Mwp) = 1.186 Mwp - 1.222
 
    magnitude, summary (M)
 


### PR DESCRIPTION
## Summary

The glossary entry for `Mw(Mwp)` listed incorrect coefficients:

```
Mw(Mwp) = 1.31 Mwp - 1.91   ← wrong
```

The correct formula derived from Whitmore et al. (2002) is:

```
Mw(Mwp) = 1.186 Mwp - 1.222
```

## Derivation

Whitmore et al. (2002) (*Science of Tsunami Hazards*, Vol. 20, No. 4, p. 187) present the linear least-squares fit:

> Average Mwp = 0.843 · Mw + 1.03

Inverting to express Mw as a function of Mwp:

> Mw = (Mwp − 1.03) / 0.843 = **1.186 · Mwp − 1.222**

This matches what is already implemented in `processing/magnitudes/Mwp.cpp`:

```cpp
const double a=1.186, b=-1.222; // Whitmore et al. (2002)
estimation = a * magnitude + b;
```

The documentation was inconsistent with both the source code and the cited paper.